### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/burn.el
+++ b/burn.el
@@ -11,8 +11,8 @@
 
 ;;; Code:
 
-(setf burn--emoji "🔥")
-(setf burn--interval 0.001)
+(defvar burn--emoji "🔥")
+(defvar burn--interval 0.001)
 
 (defun burn--is-empty ()
   (= 0 (length


### PR DESCRIPTION
Use defvar instead of setq for global variables

```
burn.el:14:7:Warning: assignment to free variable ‘burn--emoji’
burn.el:15:7:Warning: assignment to free variable ‘burn--interval’

In burn--is-empty:
burn.el:20:78:Warning: reference to free variable ‘burn--emoji’

In burn--replace-backward-at-point:
burn.el:24:47:Warning: reference to free variable ‘burn--emoji’

In burn--replace-forward-at-point:
burn.el:29:46:Warning: reference to free variable ‘burn--emoji’

In burn-code:
burn.el:37:14:Warning: reference to free variable ‘burn--interval’
```